### PR TITLE
Feat/dependabot and cicd implementation

### DIFF
--- a/carts-microservice/.github/dependabot.yml
+++ b/carts-microservice/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/carts-microservice/.github/workflows/CI.yml
+++ b/carts-microservice/.github/workflows/CI.yml
@@ -1,0 +1,11 @@
+name: Continuous Integration (CI) pipeline of the Cart microservice
+
+on:
+    pull_request:
+        types: [opened, reopened, edited]
+jobs:
+    first_job:
+        runs-on: ubuntu-latest
+        steps:
+            - run: echo "hello world"
+


### PR DESCRIPTION
init workflow file, just for testing

init dependabot config for testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced automated dependency update configuration using Dependabot (version 2) with weekly checks for Maven dependencies at the repository root.
  - Added a minimal continuous integration workflow named “Continuous Integration (CI) pipeline of the Cart microservice,” triggered on pull request events (opened, reopened, edited) and executing a basic validation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->